### PR TITLE
docs(#25): Update `refactoring` section in `report.md` to include Marcello's refactoring

### DIFF
--- a/report.md
+++ b/report.md
@@ -76,7 +76,7 @@ Carried out refactoring (optional, P+):
 - For `humanize_delta@utils/time.py`, we have [PR #4](https://github.com/dd2480-spring-2025-group-1/bot/pull/4) which reduces CCN by 37.5%.
 - For `actions_for@./bot/exts/filtering/_filter_lists/invite.py`, we have [PR #22](https://github.com/dd2480-spring-2025-group-1/bot/pull/22) which reduces CCN by 35.1%.
 
-Note: since the `on_command_error` function already has 100% test coverage as reported the projects test coverage measuring tool, we decided to do part 2 of the assignment with `actions_for` instead, which is the function with the highest CCN reported by lizard (CCN 37) and it has 20% test coverage.
+Note: since the `on_command_error` function already has 100% test coverage as reported by `coverage.py`, we decided to do part 2 of the assignment with `actions_for` instead, which is the function with the highest CCN as reported by lizard (CCN 37) and it has 20% test coverage.
 
 ## Coverage
 

--- a/report.md
+++ b/report.md
@@ -76,6 +76,7 @@ Carried out refactoring (optional, P+):
 - For `humanize_delta@utils/time.py`, we have [PR #4](https://github.com/dd2480-spring-2025-group-1/bot/pull/4) which reduces CCN by 37.5%.
 - For `apply_for@./bot/exts/filtering/_filter_lists/invite.py`, we have [PR #22](https://github.com/dd2480-spring-2025-group-1/bot/pull/22) which reduces CCN by 35.1%.
 
+Note: since the `on_command_error` function already has 100% test coverage as reported the projects test coverage measuring tool, we decided to do part 2 of the assignment with `apply_for` instead, which is the function with the highest CCN reported by lizard (CCN 37) and it has 20% test coverage.
 
 ## Coverage
 

--- a/report.md
+++ b/report.md
@@ -66,17 +66,17 @@ With everything combined, we deemed the project suitable for this assignment.
 
 Plan for refactoring complex code:
 - For `humanize_delta@utils/time.py`, we plan on extracting methods, as the function is composed of two main parts, parsing of overload arguments into time delta, and stringification of the delta. Arguably, the former can be delegated to a separate helper function, which should greatly reduce the cyclomatic complexity.  
-- For `apply_for@./bot/exts/filtering/_filter_lists/invite.py`, we plan on extracting methods, as the function is composed of many steps that can be isolated into separate functions. One could extract functionalities like redefining invites, sorting invites, finding blocked invites and cleaning up invites into separate functions.  
+- For `actions_for@./bot/exts/filtering/_filter_lists/invite.py`, we plan on extracting methods, as the function is composed of many steps that can be isolated into separate functions. One could extract functionalities like redefining invites, sorting invites, finding blocked invites and cleaning up invites into separate functions.  
 
 Estimated impact of refactoring (lower CC, but other drawbacks?):
 - For `humanize_delta@utils/time.py`, no drawbacks are anticipated, except for the use of `typing.Any` in the type signature for the new helper function. However, since type hints are not strongly enforced in Python (they're just **hints** for humans), this should not be a huge deal.
--  For `apply_for@./bot/exts/filtering/_filter_lists/invite.py`, no drawbacks are anticipated.
+-  For `actions_for@./bot/exts/filtering/_filter_lists/invite.py`, no drawbacks are anticipated.
 
 Carried out refactoring (optional, P+):
 - For `humanize_delta@utils/time.py`, we have [PR #4](https://github.com/dd2480-spring-2025-group-1/bot/pull/4) which reduces CCN by 37.5%.
-- For `apply_for@./bot/exts/filtering/_filter_lists/invite.py`, we have [PR #22](https://github.com/dd2480-spring-2025-group-1/bot/pull/22) which reduces CCN by 35.1%.
+- For `actions_for@./bot/exts/filtering/_filter_lists/invite.py`, we have [PR #22](https://github.com/dd2480-spring-2025-group-1/bot/pull/22) which reduces CCN by 35.1%.
 
-Note: since the `on_command_error` function already has 100% test coverage as reported the projects test coverage measuring tool, we decided to do part 2 of the assignment with `apply_for` instead, which is the function with the highest CCN reported by lizard (CCN 37) and it has 20% test coverage.
+Note: since the `on_command_error` function already has 100% test coverage as reported the projects test coverage measuring tool, we decided to do part 2 of the assignment with `actions_for` instead, which is the function with the highest CCN reported by lizard (CCN 37) and it has 20% test coverage.
 
 ## Coverage
 

--- a/report.md
+++ b/report.md
@@ -66,12 +66,16 @@ With everything combined, we deemed the project suitable for this assignment.
 
 Plan for refactoring complex code:
 - For `humanize_delta@utils/time.py`, we plan on extracting methods, as the function is composed of two main parts, parsing of overload arguments into time delta, and stringification of the delta. Arguably, the former can be delegated to a separate helper function, which should greatly reduce the cyclomatic complexity.  
+- For `apply_for@./bot/exts/filtering/_filter_lists/invite.py`, we plan on extracting methods, as the function is composed of many steps that can be isolated into separate functions. One could extract functionalities like redefining invites, sorting invites, finding blocked invites and cleaning up invites into separate functions.  
 
 Estimated impact of refactoring (lower CC, but other drawbacks?):
-- For `humanize_delta@utils/time.py`, no drawbacks are anticipated, except for the use of `typing.Any` in the type signature for the new helper function. However, since type hints are not strongly enforced in Python (they're just **hints** for humans), this should not be a huge deal.  
+- For `humanize_delta@utils/time.py`, no drawbacks are anticipated, except for the use of `typing.Any` in the type signature for the new helper function. However, since type hints are not strongly enforced in Python (they're just **hints** for humans), this should not be a huge deal.
+-  For `apply_for@./bot/exts/filtering/_filter_lists/invite.py`, no drawbacks are anticipated.
 
 Carried out refactoring (optional, P+):
 - For `humanize_delta@utils/time.py`, we have [PR #4](https://github.com/dd2480-spring-2025-group-1/bot/pull/4) which reduces CCN by 37.5%.
+- For `apply_for@./bot/exts/filtering/_filter_lists/invite.py`, we have [PR #22](https://github.com/dd2480-spring-2025-group-1/bot/pull/22) which reduces CCN by 35.1%.
+
 
 ## Coverage
 


### PR DESCRIPTION
Add refactoring info about `apply_for` function located at `./bot/exts/filtering/_filter_lists/invite.py`, aiming to close issue #25 
